### PR TITLE
ユーザー認証とdeviseのカラムの許可を追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   before_action :basic_auth, if: :production?
-  
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+
   private
 
   def basic_auth
@@ -12,6 +14,13 @@ class ApplicationController < ActionController::Base
 
   def production?
     Rails.env.production?
+  end
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :last_name, :first_name,
+                                      :last_name_read, :first_name_read, :gender, :birthday])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:nickname, :last_name, :first_name,
+                                      :last_name_read, :first_name_read, :gender, :birthday])
   end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,6 @@
 class ItemsController < ApplicationController
+  before_action :authenticate_user!, except: [:index, :show]
+
   def index
     @items_new = Item.all.order("created_at DESC")
     @items_archive = Item.all


### PR DESCRIPTION
# What
items_controller.rbにユーザー認証を追加
application_controller.rbにdeviseのカラムの許可を追加

# Why
before_actionで予めユーザー認証とカラム許可を記述することにより、閲覧を制限し、新規ユーザー登録・ユーザー編集を可能にした。